### PR TITLE
Update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-rhsplib
 
-This package enables Node.js applications to use RHSPlib.
+This package enables Node.js applications to control devices that speak the REV Hub Serial Protocol (such as the REV Robotics Expansion Hub).
 
 ## Making a release
 


### PR DESCRIPTION
RHSPLib isn't currently public outside of this repository, so we shouldn't just defer to it for an explanation of what this repository does.