### PR TITLE
Fix declarations file

### DIFF
--- a/dist/binding.d.ts
+++ b/dist/binding.d.ts
@@ -114,10 +114,17 @@ export interface PIDCoefficients {
 }
 export declare class Serial {
     constructor();
-    open(serialPortName: string, baudrate: number, databits: number, parity: SerialParity, stopbits: number, flowControl: SerialFlowControl): void;
+    open(serialPortName: string, baudrate: number, databits: number, parity: SerialParity, stopbits: number, flowControl: SerialFlowControl): Promise<{
+        resultCode: number;
+    }>;
     close(): void;
-    read(numBytesToRead: number): number[];
-    write(bytes: number[]): void;
+    read(numBytesToRead: number): Promise<{
+        resultCode: number;
+        value: number[];
+    }>;
+    write(bytes: number[]): Promise<{
+        resultCode: number;
+    }>;
 }
 export declare class RHSPlib {
     constructor();

--- a/dist/binding.d.ts
+++ b/dist/binding.d.ts
@@ -185,7 +185,7 @@ export declare class RHSPlib {
     setDebugLogLevel(debugGroup: DebugGroup, verbosityLevel: VerbosityLevel): Promise<{
         resultCode: number;
     }>;
-    discovery(serialPort: Serial): Promise<{
+    static discovery(serialPort: Serial): Promise<{
         value?: DiscoveredAddresses;
         resultCode: number;
     }>;

--- a/dist/binding.js
+++ b/dist/binding.js
@@ -1,6 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.I2CSpeedCode = exports.DIODirection = exports.VerbosityLevel = exports.DebugGroup = exports.SerialFlowControl = exports.SerialParity = void 0;
+var addon = require('bindings')('addon');
+module.exports.Serial = addon.Serial;
+module.exports.RHSPlib = addon.RHSPlib;
 var SerialParity;
 (function (SerialParity) {
     SerialParity[SerialParity["None"] = 0] = "None";

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -1,3 +1,8 @@
+const addon = require('bindings')('addon');
+
+module.exports.Serial = addon.Serial;
+module.exports.RHSPlib = addon.RHSPlib;
+
 export enum SerialParity {
   None = 0,
   Odd,

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -159,7 +159,7 @@ export declare class RHSPlib {
   setModuleLEDPattern(ledPattern: LEDPattern): Promise<{resultCode: number}>;
   getModuleLEDPattern(): Promise<{value?: LEDPattern, resultCode: number}>;
   setDebugLogLevel(debugGroup: DebugGroup, verbosityLevel: VerbosityLevel): Promise<{resultCode: number}>;
-  discovery(serialPort: Serial): Promise<{value?: DiscoveredAddresses, resultCode: number}>;
+  static discovery(serialPort: Serial): Promise<{value?: DiscoveredAddresses, resultCode: number}>;
   getInterfacePacketID(interfaceName: string, functionNumber: number): Promise<{value?: number, resultCode: number}>;
 
   // Device Control

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -130,10 +130,10 @@ export interface PIDCoefficients {
 
 export declare class Serial {
   constructor();
-  open(serialPortName: string, baudrate: number, databits: number, parity: SerialParity, stopbits: number, flowControl: SerialFlowControl): void;
+  open(serialPortName: string, baudrate: number, databits: number, parity: SerialParity, stopbits: number, flowControl: SerialFlowControl): Promise<{resultCode: number}>;
   close(): void;
-  read(numBytesToRead: number): number[];
-  write(bytes: number[]): void;
+  read(numBytesToRead: number): Promise<{resultCode: number, value: number[]}>;
+  write(bytes: number[]): Promise<{resultCode: number}>;
 }
 
 export declare class RHSPlib {


### PR DESCRIPTION
fixes #11 - Exported Serial and RHSPlib with module.exports -- unsure if this is the right way to do it. Like I said, I wasn't able to find any examples of declaring node add-on classes for typescript.
fixes #10 
fixes #9 