### PR TITLE
Add scoped lock for async worker execution

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,8 @@
       'sources': [
         'src/addon.cc',
         'src/RevHubWrapper.cc',
-        'src/serialWrapper.cc'
+        'src/serialWrapper.cc',
+        'src/RHSPlibWorker.cc'
       ],
       'include_dirs': [
         'src/',

--- a/src/RHSPlibWorker.cc
+++ b/src/RHSPlibWorker.cc
@@ -1,0 +1,3 @@
+#include "RHSPlibWorker.h"
+
+std::mutex RHSPlibWorkerBase::m_mutex;


### PR DESCRIPTION
Thought it would be easier, but it was a bit tricky because the RHSPlibWorker class is templated and also specialized, so I had to do it like this. Let me know if there are any issues.

closes #4