### PR TITLE
Add caching mechanism for builds

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -5,8 +5,7 @@
       "options": {
         "cacheableOperations": [
           "build",
-          "install",
-          "list"
+          "install"
         ]
       }
     }
@@ -31,11 +30,6 @@
     "prepublishOnly": {
       "dependsOn": [
         "^prepublishOnly"
-      ]
-    },
-    "list": {
-      "dependsOn": [
-        "^list"
       ]
     }
   }

--- a/nx.json
+++ b/nx.json
@@ -31,6 +31,11 @@
       "dependsOn": [
         "^prepublishOnly"
       ]
+    },
+    "list": {
+      "dependsOn": [
+        "build"
+      ]
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,42 @@
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": [
+          "build",
+          "install",
+          "list"
+        ]
+      }
+    }
+  },
+  "targetDefaults": {
+    "build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "{projectRoot}/dist"
+      ]
+    },
+    "install": {
+      "dependsOn": [
+        "^install"
+      ],
+      "outputs": [
+        "{projectRoot}/prebuilds"
+      ]
+    },
+    "prepublishOnly": {
+      "dependsOn": [
+        "^prepublishOnly"
+      ]
+    },
+    "list": {
+      "dependsOn": [
+        "^list"
+      ]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "packages/*"
       ],
       "devDependencies": {
-        "lerna": "^6.0.1"
+        "lerna": "^6.0.1",
+        "nx": "^16.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1390,12 +1391,233 @@
       }
     },
     "node_modules/@nrwl/cli": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.3.tgz",
-      "integrity": "sha512-qiAKHkov3iBx6hroPTitUrkRSUZFQqVgNJiF9gXRFC6pNJe9RS4rlmcIaoUFOboi9CnH5jwblNJVcz8YSVYOvA==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.4.tgz",
+      "integrity": "sha512-FoiGFCLpb/r4HXCM3KYqT0xteP+MRV6bIHjz3bdPHIDLmBNQQnRRaV2K47jtJ6zjh1eOU5UHKyDtDDYf80Idpw==",
       "dev": true,
       "dependencies": {
-        "nx": "15.9.3"
+        "nx": "15.9.4"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/@nrwl/tao": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.4.tgz",
+      "integrity": "sha512-m90iz8UsXx1rgPm1dxsBQjSrCViWYZIrp8bpwjSCW24j3kifyilYSXGuKaRwZwUn7eNmH/kZcI9/8qeGIPF4Sg==",
+      "dev": true,
+      "dependencies": {
+        "nx": "15.9.4"
+      },
+      "bin": {
+        "tao": "index.js"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/fast-glob": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/nx": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.4.tgz",
+      "integrity": "sha512-P1G4t59UvE/lkHyruLeSOB5ZuNyh01IwU0tTUOi8f9s/NbP7+OQ8MYVwDV74JHTr6mQgjlS+n+4Eox8tVm9itA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@nrwl/cli": "15.9.4",
+        "@nrwl/tao": "15.9.4",
+        "@parcel/watcher": "2.0.4",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "@yarnpkg/parsers": "^3.0.0-rc.18",
+        "@zkochan/js-yaml": "0.0.6",
+        "axios": "^1.0.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "^7.0.2",
+        "dotenv": "~10.0.0",
+        "enquirer": "~2.3.6",
+        "fast-glob": "3.2.7",
+        "figures": "3.2.0",
+        "flat": "^5.0.2",
+        "fs-extra": "^11.1.0",
+        "glob": "7.1.4",
+        "ignore": "^5.0.4",
+        "js-yaml": "4.1.0",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "~2.0.3",
+        "minimatch": "3.0.5",
+        "npm-run-path": "^4.0.1",
+        "open": "^8.4.0",
+        "semver": "7.3.4",
+        "string-width": "^4.2.3",
+        "strong-log-transformer": "^2.1.0",
+        "tar-stream": "~2.2.0",
+        "tmp": "~0.2.1",
+        "tsconfig-paths": "^4.1.2",
+        "tslib": "^2.3.0",
+        "v8-compile-cache": "2.3.0",
+        "yargs": "^17.6.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "bin/nx.js"
+      },
+      "optionalDependencies": {
+        "@nrwl/nx-darwin-arm64": "15.9.4",
+        "@nrwl/nx-darwin-x64": "15.9.4",
+        "@nrwl/nx-linux-arm-gnueabihf": "15.9.4",
+        "@nrwl/nx-linux-arm64-gnu": "15.9.4",
+        "@nrwl/nx-linux-arm64-musl": "15.9.4",
+        "@nrwl/nx-linux-x64-gnu": "15.9.4",
+        "@nrwl/nx-linux-x64-musl": "15.9.4",
+        "@nrwl/nx-win32-arm64-msvc": "15.9.4",
+        "@nrwl/nx-win32-x64-msvc": "15.9.4"
+      },
+      "peerDependencies": {
+        "@swc-node/register": "^1.4.2",
+        "@swc/core": "^1.2.173"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@nrwl/cli/node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@nrwl/devkit": {
@@ -1442,9 +1664,9 @@
       }
     },
     "node_modules/@nrwl/nx-darwin-arm64": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.3.tgz",
-      "integrity": "sha512-2htJzVa+S/uLg5tj4nbO/tRz2SRMQIpT6EeWMgDGuEKQdpuRLVj2ez9hMpkRn9tl1tBUwR05hbV28DnOLRESVA==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.4.tgz",
+      "integrity": "sha512-XnvrnT9BJsgThY/4xUcYtE077ERq/img8CkRj7MOOBNOh0/nVcR4LGbBKDHtwE3HPk0ikyS/SxRyNa9msvi3QQ==",
       "cpu": [
         "arm64"
       ],
@@ -1458,9 +1680,9 @@
       }
     },
     "node_modules/@nrwl/nx-darwin-x64": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.3.tgz",
-      "integrity": "sha512-p+8UkfC6KTLOX4XRt7NSP8DoTzEgs73+SN0csoXT9VsNO35+F0Z5zMZxpEc7RVo5Wen/4PGh2OWA+8gtgntsJQ==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.4.tgz",
+      "integrity": "sha512-WKSfSlpVMLchpXkax0geeUNyhvNxwO7qUz/s0/HJWBekt8fizwKDwDj1gP7fOu+YWb/tHiSscbR1km8PtdjhQw==",
       "cpu": [
         "x64"
       ],
@@ -1474,9 +1696,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-arm-gnueabihf": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.3.tgz",
-      "integrity": "sha512-xwW7bZtggrxhFbYvvWWArtcSWwoxWzi/4wNgP3wPbcZFNZiraahVQSpIyJXrS9aajGbdvuDBM8cbDsMj9v7mwg==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.4.tgz",
+      "integrity": "sha512-a/b4PP7lP/Cgrh0LjC4O2YTt5pyf4DQTGtuE8qlo8o486UiofCtk4QGJX72q80s23L0ejCaKY2ULKx/3zMLjuA==",
       "cpu": [
         "arm"
       ],
@@ -1490,9 +1712,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-arm64-gnu": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.3.tgz",
-      "integrity": "sha512-KNxDL2OAHxhFqztEjv2mNwXD6xrzoUury7NsYZYqlxJUNc3YYBfRSLEatnw491crvMBndbxfGVTWEO9S4YmRuw==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.4.tgz",
+      "integrity": "sha512-ibBV8fMhSfLVd/2WzcDuUm32BoZsattuKkvMmOoyU6Pzoznc3AqyDjJR4xCIoAn5Rf+Nu1oeQONr5FAtb1Ugow==",
       "cpu": [
         "arm64"
       ],
@@ -1506,9 +1728,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-arm64-musl": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.3.tgz",
-      "integrity": "sha512-AxoZzfsXH7ZqDE+WrQtRumufIcSIBw4U/LikiDLaWWoGtNpAfKLkD/PHirZiNxHIeGy1Toi4ccMUolXbafLVFw==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.4.tgz",
+      "integrity": "sha512-iIjvVYd7+uM4jVD461+PvU5XTALgSvJOODUaMRGOoDl0KlMuTe6pQZlw0eXjl5rcTd6paKaVFWT5j6awr8kj7w==",
       "cpu": [
         "arm64"
       ],
@@ -1522,9 +1744,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-x64-gnu": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.3.tgz",
-      "integrity": "sha512-P8AOPRufvV4a5cSczNsw84zFAI7NgAiEBTybYcyymdNJmo0iArJXEmvj/G4mB20O8VCsCkwqMYAu6nQEnES1Kw==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.4.tgz",
+      "integrity": "sha512-q4OyH72mdrE4KellBWtwpr5EwfxHKNoFP9//7FAILO68ROh0rpMd7YQMlTB7T04UEUHjKEEsFGTlVXIee3Viwg==",
       "cpu": [
         "x64"
       ],
@@ -1538,9 +1760,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-x64-musl": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.3.tgz",
-      "integrity": "sha512-4ZYDp7T319+xbw7Z7KVtRefzaXJipZfgrM49r+Y1FAfYDc8y18zvKz3slK26wfWz+EUZwKsa/DfA2KmyRG3DvQ==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.4.tgz",
+      "integrity": "sha512-67+/XNMR1CgLPyeGX8jqSG6l8yYD0iiwUgcu1Vaxq6N05WwnqVisIW8XzLSRUtKt4WyVQgOWk3aspImpMVOG3Q==",
       "cpu": [
         "x64"
       ],
@@ -1554,9 +1776,9 @@
       }
     },
     "node_modules/@nrwl/nx-win32-arm64-msvc": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.3.tgz",
-      "integrity": "sha512-UhgxIPgTZBKN1oxlLPSklkSzVL3hA4lAiVc9A0Utumpbp0ob/Xx+2vHzg3cnmNH3jWkZ+9OsC2dKyeMB6gAbSw==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.4.tgz",
+      "integrity": "sha512-2rEsq3eOGVCYpYJn2tTJkOGNJm/U8rP/FmqtZXYa6VJv/00XP3Gl00IXFEDaYV6rZo7SWqLxtEPUbjK5LwPzZA==",
       "cpu": [
         "arm64"
       ],
@@ -1570,9 +1792,9 @@
       }
     },
     "node_modules/@nrwl/nx-win32-x64-msvc": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.3.tgz",
-      "integrity": "sha512-gdnvqURKnu0EQGOFJ6NUKq6wSB+viNb7Z8qtKhzSmFwVjT8akOnLWn7ZhL9v28TAjLM7/s1Mwvmz/IMj1PGlcQ==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.4.tgz",
+      "integrity": "sha512-bogVju4Z/hy1jbppqaTNbmV1R4Kg0R5fKxXAXC2LaL7FL0dup31wPumdV+mXttXBNOBDjV8V/Oz1ZqdmxpOJUw==",
       "cpu": [
         "x64"
       ],
@@ -1586,15 +1808,159 @@
       }
     },
     "node_modules/@nrwl/tao": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.3.tgz",
-      "integrity": "sha512-NcjFCbuMa53C3fBrK7qLUImUBySyr9EVwmiZuAv9sZZtm4eILK8w3qihjrB4FFUuLjPU/SViriYXi+hF2tbP4w==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.2.1.tgz",
+      "integrity": "sha512-mhLkMxGFbnR4hu9UbjMvzdePDXmUpV33mImt1myewP/cY9YZdzv5ntqT+9U+zzVg7Q2ZGosiGQE+IYRm6yeWog==",
       "dev": true,
       "dependencies": {
-        "nx": "15.9.3"
+        "nx": "16.2.1"
       },
       "bin": {
         "tao": "index.js"
+      }
+    },
+    "node_modules/@nx/nx-darwin-arm64": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.2.1.tgz",
+      "integrity": "sha512-xK/dL5T2R8zrcD8/13PeaYH/LBcYeaELIZkXGdGbtQ8WeFHjPJLBfuWo/7Se7KSWIXLIJEeYrVZwyxuei1dOTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-darwin-x64": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.2.1.tgz",
+      "integrity": "sha512-J1ZBqy8FtIhvZopcc96JWZY2InZClQ+XHWHnAmX8S1f79hcLUiatpu90FZhvfXmfOfLlpkKsa8aje/kjpnnWhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.2.1.tgz",
+      "integrity": "sha512-rnujPmWlnkEvzkWARuW85cizVx6uGwQ/gA84tK3cHZQf9ly172WbDtsMtYRS9/CjvysMqDV0zBd7o/YhwpXNZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.2.1.tgz",
+      "integrity": "sha512-ZcuQN8eaxEI+93ut6UrDrZMPsk61LGlS6yaWPgrv3blKMfcU2+DYBDQ3ois7o5t0bnVad5QYSNhIvnMF2iU+hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.2.1.tgz",
+      "integrity": "sha512-mMOvkYyBLU4j+mSHobtrj/pIDYXFGIX3Q9FMWxZ5Xz15m0DsbypZ/8v6NWpJaBY4VX6rJhCc+D/pZH+QBT8+/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.2.1.tgz",
+      "integrity": "sha512-Kyn4dxFTj2PCRv+39tKU8BzDRE6/ru5v435uvodx03GS650F7+OMr4DN57jG4MQWhf//OUX8zPkvbKhsmxjndA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-x64-musl": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.2.1.tgz",
+      "integrity": "sha512-q8iFxLosSLiWkRWsbrioXV/qMG8TgsbqcM0VGz2FFLNMJ9DXvav/E/+8YbgEeHOjvA1MDeRaspIpDF7OMgJYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.2.1.tgz",
+      "integrity": "sha512-PpGiYzrMivDY1i10Zwf5Hmnv6oAQ8ACf6ehDgyQ3tByMMXHgyUZJLykfPaoWjoLh0s8wOvMV74WZO+K1LcIxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.2.1.tgz",
+      "integrity": "sha512-m5oHCaSKdyydM1n1W9V0m2oxBL8PiF54dZB0+PlKB2fhf1zxiyq8i1hL2hXbKA90IOYcUt5/b7761/BzN5njAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -4527,6 +4893,186 @@
         "node": "^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/lerna/node_modules/@nrwl/tao": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.4.tgz",
+      "integrity": "sha512-m90iz8UsXx1rgPm1dxsBQjSrCViWYZIrp8bpwjSCW24j3kifyilYSXGuKaRwZwUn7eNmH/kZcI9/8qeGIPF4Sg==",
+      "dev": true,
+      "dependencies": {
+        "nx": "15.9.4"
+      },
+      "bin": {
+        "tao": "index.js"
+      }
+    },
+    "node_modules/lerna/node_modules/fast-glob": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lerna/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/lerna/node_modules/glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lerna/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lerna/node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lerna/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lerna/node_modules/nx": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.4.tgz",
+      "integrity": "sha512-P1G4t59UvE/lkHyruLeSOB5ZuNyh01IwU0tTUOi8f9s/NbP7+OQ8MYVwDV74JHTr6mQgjlS+n+4Eox8tVm9itA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@nrwl/cli": "15.9.4",
+        "@nrwl/tao": "15.9.4",
+        "@parcel/watcher": "2.0.4",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "@yarnpkg/parsers": "^3.0.0-rc.18",
+        "@zkochan/js-yaml": "0.0.6",
+        "axios": "^1.0.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "^7.0.2",
+        "dotenv": "~10.0.0",
+        "enquirer": "~2.3.6",
+        "fast-glob": "3.2.7",
+        "figures": "3.2.0",
+        "flat": "^5.0.2",
+        "fs-extra": "^11.1.0",
+        "glob": "7.1.4",
+        "ignore": "^5.0.4",
+        "js-yaml": "4.1.0",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "~2.0.3",
+        "minimatch": "3.0.5",
+        "npm-run-path": "^4.0.1",
+        "open": "^8.4.0",
+        "semver": "7.3.4",
+        "string-width": "^4.2.3",
+        "strong-log-transformer": "^2.1.0",
+        "tar-stream": "~2.2.0",
+        "tmp": "~0.2.1",
+        "tsconfig-paths": "^4.1.2",
+        "tslib": "^2.3.0",
+        "v8-compile-cache": "2.3.0",
+        "yargs": "^17.6.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "bin/nx.js"
+      },
+      "optionalDependencies": {
+        "@nrwl/nx-darwin-arm64": "15.9.4",
+        "@nrwl/nx-darwin-x64": "15.9.4",
+        "@nrwl/nx-linux-arm-gnueabihf": "15.9.4",
+        "@nrwl/nx-linux-arm64-gnu": "15.9.4",
+        "@nrwl/nx-linux-arm64-musl": "15.9.4",
+        "@nrwl/nx-linux-x64-gnu": "15.9.4",
+        "@nrwl/nx-linux-x64-musl": "15.9.4",
+        "@nrwl/nx-win32-arm64-msvc": "15.9.4",
+        "@nrwl/nx-win32-x64-msvc": "15.9.4"
+      },
+      "peerDependencies": {
+        "@swc-node/register": "^1.4.2",
+        "@swc/core": "^1.2.173"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lerna/node_modules/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lerna/node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -4538,6 +5084,47 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/lerna/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lerna/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lerna/node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/libnpmaccess": {
@@ -5637,14 +6224,13 @@
       }
     },
     "node_modules/nx": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.3.tgz",
-      "integrity": "sha512-GLwbykfTABc7/UZjQEEnV1bQbTVC53W+Zj4xWY640/45I4iZf/TUqKMBCgtLZ9v89gEsKOM4zsx55CqHT3bekA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-16.2.1.tgz",
+      "integrity": "sha512-O+yGcYIQtYKYagbIuOQFk1P8ki5PHn0BZjdZpsa4K8UZ4pCaRWzlwWwwUL91FUJe6tdhic5710DwAAakbGKP7Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@nrwl/cli": "15.9.3",
-        "@nrwl/tao": "15.9.3",
+        "@nrwl/tao": "16.2.1",
         "@parcel/watcher": "2.0.4",
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "^3.0.0-rc.18",
@@ -5683,15 +6269,15 @@
         "nx": "bin/nx.js"
       },
       "optionalDependencies": {
-        "@nrwl/nx-darwin-arm64": "15.9.3",
-        "@nrwl/nx-darwin-x64": "15.9.3",
-        "@nrwl/nx-linux-arm-gnueabihf": "15.9.3",
-        "@nrwl/nx-linux-arm64-gnu": "15.9.3",
-        "@nrwl/nx-linux-arm64-musl": "15.9.3",
-        "@nrwl/nx-linux-x64-gnu": "15.9.3",
-        "@nrwl/nx-linux-x64-musl": "15.9.3",
-        "@nrwl/nx-win32-arm64-msvc": "15.9.3",
-        "@nrwl/nx-win32-x64-msvc": "15.9.3"
+        "@nx/nx-darwin-arm64": "16.2.1",
+        "@nx/nx-darwin-x64": "16.2.1",
+        "@nx/nx-linux-arm-gnueabihf": "16.2.1",
+        "@nx/nx-linux-arm64-gnu": "16.2.1",
+        "@nx/nx-linux-arm64-musl": "16.2.1",
+        "@nx/nx-linux-x64-gnu": "16.2.1",
+        "@nx/nx-linux-x64-musl": "16.2.1",
+        "@nx/nx-win32-arm64-msvc": "16.2.1",
+        "@nx/nx-win32-x64-msvc": "16.2.1"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.4.2",
@@ -9024,12 +9610,183 @@
       }
     },
     "@nrwl/cli": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.3.tgz",
-      "integrity": "sha512-qiAKHkov3iBx6hroPTitUrkRSUZFQqVgNJiF9gXRFC6pNJe9RS4rlmcIaoUFOboi9CnH5jwblNJVcz8YSVYOvA==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.4.tgz",
+      "integrity": "sha512-FoiGFCLpb/r4HXCM3KYqT0xteP+MRV6bIHjz3bdPHIDLmBNQQnRRaV2K47jtJ6zjh1eOU5UHKyDtDDYf80Idpw==",
       "dev": true,
       "requires": {
-        "nx": "15.9.3"
+        "nx": "15.9.4"
+      },
+      "dependencies": {
+        "@nrwl/tao": {
+          "version": "15.9.4",
+          "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.4.tgz",
+          "integrity": "sha512-m90iz8UsXx1rgPm1dxsBQjSrCViWYZIrp8bpwjSCW24j3kifyilYSXGuKaRwZwUn7eNmH/kZcI9/8qeGIPF4Sg==",
+          "dev": true,
+          "requires": {
+            "nx": "15.9.4"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+          "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "fs-extra": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "nx": {
+          "version": "15.9.4",
+          "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.4.tgz",
+          "integrity": "sha512-P1G4t59UvE/lkHyruLeSOB5ZuNyh01IwU0tTUOi8f9s/NbP7+OQ8MYVwDV74JHTr6mQgjlS+n+4Eox8tVm9itA==",
+          "dev": true,
+          "requires": {
+            "@nrwl/cli": "15.9.4",
+            "@nrwl/nx-darwin-arm64": "15.9.4",
+            "@nrwl/nx-darwin-x64": "15.9.4",
+            "@nrwl/nx-linux-arm-gnueabihf": "15.9.4",
+            "@nrwl/nx-linux-arm64-gnu": "15.9.4",
+            "@nrwl/nx-linux-arm64-musl": "15.9.4",
+            "@nrwl/nx-linux-x64-gnu": "15.9.4",
+            "@nrwl/nx-linux-x64-musl": "15.9.4",
+            "@nrwl/nx-win32-arm64-msvc": "15.9.4",
+            "@nrwl/nx-win32-x64-msvc": "15.9.4",
+            "@nrwl/tao": "15.9.4",
+            "@parcel/watcher": "2.0.4",
+            "@yarnpkg/lockfile": "^1.1.0",
+            "@yarnpkg/parsers": "^3.0.0-rc.18",
+            "@zkochan/js-yaml": "0.0.6",
+            "axios": "^1.0.0",
+            "chalk": "^4.1.0",
+            "cli-cursor": "3.1.0",
+            "cli-spinners": "2.6.1",
+            "cliui": "^7.0.2",
+            "dotenv": "~10.0.0",
+            "enquirer": "~2.3.6",
+            "fast-glob": "3.2.7",
+            "figures": "3.2.0",
+            "flat": "^5.0.2",
+            "fs-extra": "^11.1.0",
+            "glob": "7.1.4",
+            "ignore": "^5.0.4",
+            "js-yaml": "4.1.0",
+            "jsonc-parser": "3.2.0",
+            "lines-and-columns": "~2.0.3",
+            "minimatch": "3.0.5",
+            "npm-run-path": "^4.0.1",
+            "open": "^8.4.0",
+            "semver": "7.3.4",
+            "string-width": "^4.2.3",
+            "strong-log-transformer": "^2.1.0",
+            "tar-stream": "~2.2.0",
+            "tmp": "~0.2.1",
+            "tsconfig-paths": "^4.1.2",
+            "tslib": "^2.3.0",
+            "v8-compile-cache": "2.3.0",
+            "yargs": "^17.6.2",
+            "yargs-parser": "21.1.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "8.0.1",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+              "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+              "dev": true,
+              "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
       }
     },
     "@nrwl/devkit": {
@@ -9066,76 +9823,139 @@
       }
     },
     "@nrwl/nx-darwin-arm64": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.3.tgz",
-      "integrity": "sha512-2htJzVa+S/uLg5tj4nbO/tRz2SRMQIpT6EeWMgDGuEKQdpuRLVj2ez9hMpkRn9tl1tBUwR05hbV28DnOLRESVA==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.4.tgz",
+      "integrity": "sha512-XnvrnT9BJsgThY/4xUcYtE077ERq/img8CkRj7MOOBNOh0/nVcR4LGbBKDHtwE3HPk0ikyS/SxRyNa9msvi3QQ==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-darwin-x64": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.3.tgz",
-      "integrity": "sha512-p+8UkfC6KTLOX4XRt7NSP8DoTzEgs73+SN0csoXT9VsNO35+F0Z5zMZxpEc7RVo5Wen/4PGh2OWA+8gtgntsJQ==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.4.tgz",
+      "integrity": "sha512-WKSfSlpVMLchpXkax0geeUNyhvNxwO7qUz/s0/HJWBekt8fizwKDwDj1gP7fOu+YWb/tHiSscbR1km8PtdjhQw==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-arm-gnueabihf": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.3.tgz",
-      "integrity": "sha512-xwW7bZtggrxhFbYvvWWArtcSWwoxWzi/4wNgP3wPbcZFNZiraahVQSpIyJXrS9aajGbdvuDBM8cbDsMj9v7mwg==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.4.tgz",
+      "integrity": "sha512-a/b4PP7lP/Cgrh0LjC4O2YTt5pyf4DQTGtuE8qlo8o486UiofCtk4QGJX72q80s23L0ejCaKY2ULKx/3zMLjuA==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-arm64-gnu": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.3.tgz",
-      "integrity": "sha512-KNxDL2OAHxhFqztEjv2mNwXD6xrzoUury7NsYZYqlxJUNc3YYBfRSLEatnw491crvMBndbxfGVTWEO9S4YmRuw==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.4.tgz",
+      "integrity": "sha512-ibBV8fMhSfLVd/2WzcDuUm32BoZsattuKkvMmOoyU6Pzoznc3AqyDjJR4xCIoAn5Rf+Nu1oeQONr5FAtb1Ugow==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-arm64-musl": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.3.tgz",
-      "integrity": "sha512-AxoZzfsXH7ZqDE+WrQtRumufIcSIBw4U/LikiDLaWWoGtNpAfKLkD/PHirZiNxHIeGy1Toi4ccMUolXbafLVFw==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.4.tgz",
+      "integrity": "sha512-iIjvVYd7+uM4jVD461+PvU5XTALgSvJOODUaMRGOoDl0KlMuTe6pQZlw0eXjl5rcTd6paKaVFWT5j6awr8kj7w==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-x64-gnu": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.3.tgz",
-      "integrity": "sha512-P8AOPRufvV4a5cSczNsw84zFAI7NgAiEBTybYcyymdNJmo0iArJXEmvj/G4mB20O8VCsCkwqMYAu6nQEnES1Kw==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.4.tgz",
+      "integrity": "sha512-q4OyH72mdrE4KellBWtwpr5EwfxHKNoFP9//7FAILO68ROh0rpMd7YQMlTB7T04UEUHjKEEsFGTlVXIee3Viwg==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-x64-musl": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.3.tgz",
-      "integrity": "sha512-4ZYDp7T319+xbw7Z7KVtRefzaXJipZfgrM49r+Y1FAfYDc8y18zvKz3slK26wfWz+EUZwKsa/DfA2KmyRG3DvQ==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.4.tgz",
+      "integrity": "sha512-67+/XNMR1CgLPyeGX8jqSG6l8yYD0iiwUgcu1Vaxq6N05WwnqVisIW8XzLSRUtKt4WyVQgOWk3aspImpMVOG3Q==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-win32-arm64-msvc": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.3.tgz",
-      "integrity": "sha512-UhgxIPgTZBKN1oxlLPSklkSzVL3hA4lAiVc9A0Utumpbp0ob/Xx+2vHzg3cnmNH3jWkZ+9OsC2dKyeMB6gAbSw==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.4.tgz",
+      "integrity": "sha512-2rEsq3eOGVCYpYJn2tTJkOGNJm/U8rP/FmqtZXYa6VJv/00XP3Gl00IXFEDaYV6rZo7SWqLxtEPUbjK5LwPzZA==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-win32-x64-msvc": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.3.tgz",
-      "integrity": "sha512-gdnvqURKnu0EQGOFJ6NUKq6wSB+viNb7Z8qtKhzSmFwVjT8akOnLWn7ZhL9v28TAjLM7/s1Mwvmz/IMj1PGlcQ==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.4.tgz",
+      "integrity": "sha512-bogVju4Z/hy1jbppqaTNbmV1R4Kg0R5fKxXAXC2LaL7FL0dup31wPumdV+mXttXBNOBDjV8V/Oz1ZqdmxpOJUw==",
       "dev": true,
       "optional": true
     },
     "@nrwl/tao": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.3.tgz",
-      "integrity": "sha512-NcjFCbuMa53C3fBrK7qLUImUBySyr9EVwmiZuAv9sZZtm4eILK8w3qihjrB4FFUuLjPU/SViriYXi+hF2tbP4w==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.2.1.tgz",
+      "integrity": "sha512-mhLkMxGFbnR4hu9UbjMvzdePDXmUpV33mImt1myewP/cY9YZdzv5ntqT+9U+zzVg7Q2ZGosiGQE+IYRm6yeWog==",
       "dev": true,
       "requires": {
-        "nx": "15.9.3"
+        "nx": "16.2.1"
       }
+    },
+    "@nx/nx-darwin-arm64": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.2.1.tgz",
+      "integrity": "sha512-xK/dL5T2R8zrcD8/13PeaYH/LBcYeaELIZkXGdGbtQ8WeFHjPJLBfuWo/7Se7KSWIXLIJEeYrVZwyxuei1dOTA==",
+      "dev": true,
+      "optional": true
+    },
+    "@nx/nx-darwin-x64": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.2.1.tgz",
+      "integrity": "sha512-J1ZBqy8FtIhvZopcc96JWZY2InZClQ+XHWHnAmX8S1f79hcLUiatpu90FZhvfXmfOfLlpkKsa8aje/kjpnnWhA==",
+      "dev": true,
+      "optional": true
+    },
+    "@nx/nx-linux-arm-gnueabihf": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.2.1.tgz",
+      "integrity": "sha512-rnujPmWlnkEvzkWARuW85cizVx6uGwQ/gA84tK3cHZQf9ly172WbDtsMtYRS9/CjvysMqDV0zBd7o/YhwpXNZg==",
+      "dev": true,
+      "optional": true
+    },
+    "@nx/nx-linux-arm64-gnu": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.2.1.tgz",
+      "integrity": "sha512-ZcuQN8eaxEI+93ut6UrDrZMPsk61LGlS6yaWPgrv3blKMfcU2+DYBDQ3ois7o5t0bnVad5QYSNhIvnMF2iU+hQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@nx/nx-linux-arm64-musl": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.2.1.tgz",
+      "integrity": "sha512-mMOvkYyBLU4j+mSHobtrj/pIDYXFGIX3Q9FMWxZ5Xz15m0DsbypZ/8v6NWpJaBY4VX6rJhCc+D/pZH+QBT8+/g==",
+      "dev": true,
+      "optional": true
+    },
+    "@nx/nx-linux-x64-gnu": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.2.1.tgz",
+      "integrity": "sha512-Kyn4dxFTj2PCRv+39tKU8BzDRE6/ru5v435uvodx03GS650F7+OMr4DN57jG4MQWhf//OUX8zPkvbKhsmxjndA==",
+      "dev": true,
+      "optional": true
+    },
+    "@nx/nx-linux-x64-musl": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.2.1.tgz",
+      "integrity": "sha512-q8iFxLosSLiWkRWsbrioXV/qMG8TgsbqcM0VGz2FFLNMJ9DXvav/E/+8YbgEeHOjvA1MDeRaspIpDF7OMgJYGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@nx/nx-win32-arm64-msvc": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.2.1.tgz",
+      "integrity": "sha512-PpGiYzrMivDY1i10Zwf5Hmnv6oAQ8ACf6ehDgyQ3tByMMXHgyUZJLykfPaoWjoLh0s8wOvMV74WZO+K1LcIxTA==",
+      "dev": true,
+      "optional": true
+    },
+    "@nx/nx-win32-x64-msvc": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.2.1.tgz",
+      "integrity": "sha512-m5oHCaSKdyydM1n1W9V0m2oxBL8PiF54dZB0+PlKB2fhf1zxiyq8i1hL2hXbKA90IOYcUt5/b7761/BzN5njAw==",
+      "dev": true,
+      "optional": true
     },
     "@octokit/auth-token": {
       "version": "3.0.3",
@@ -11385,10 +12205,179 @@
         "typescript": "^3 || ^4"
       },
       "dependencies": {
+        "@nrwl/tao": {
+          "version": "15.9.4",
+          "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.4.tgz",
+          "integrity": "sha512-m90iz8UsXx1rgPm1dxsBQjSrCViWYZIrp8bpwjSCW24j3kifyilYSXGuKaRwZwUn7eNmH/kZcI9/8qeGIPF4Sg==",
+          "dev": true,
+          "requires": {
+            "nx": "15.9.4"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+          "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "fs-extra": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "nx": {
+          "version": "15.9.4",
+          "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.4.tgz",
+          "integrity": "sha512-P1G4t59UvE/lkHyruLeSOB5ZuNyh01IwU0tTUOi8f9s/NbP7+OQ8MYVwDV74JHTr6mQgjlS+n+4Eox8tVm9itA==",
+          "dev": true,
+          "requires": {
+            "@nrwl/cli": "15.9.4",
+            "@nrwl/nx-darwin-arm64": "15.9.4",
+            "@nrwl/nx-darwin-x64": "15.9.4",
+            "@nrwl/nx-linux-arm-gnueabihf": "15.9.4",
+            "@nrwl/nx-linux-arm64-gnu": "15.9.4",
+            "@nrwl/nx-linux-arm64-musl": "15.9.4",
+            "@nrwl/nx-linux-x64-gnu": "15.9.4",
+            "@nrwl/nx-linux-x64-musl": "15.9.4",
+            "@nrwl/nx-win32-arm64-msvc": "15.9.4",
+            "@nrwl/nx-win32-x64-msvc": "15.9.4",
+            "@nrwl/tao": "15.9.4",
+            "@parcel/watcher": "2.0.4",
+            "@yarnpkg/lockfile": "^1.1.0",
+            "@yarnpkg/parsers": "^3.0.0-rc.18",
+            "@zkochan/js-yaml": "0.0.6",
+            "axios": "^1.0.0",
+            "chalk": "^4.1.0",
+            "cli-cursor": "3.1.0",
+            "cli-spinners": "2.6.1",
+            "cliui": "^7.0.2",
+            "dotenv": "~10.0.0",
+            "enquirer": "~2.3.6",
+            "fast-glob": "3.2.7",
+            "figures": "3.2.0",
+            "flat": "^5.0.2",
+            "fs-extra": "^11.1.0",
+            "glob": "7.1.4",
+            "ignore": "^5.0.4",
+            "js-yaml": "4.1.0",
+            "jsonc-parser": "3.2.0",
+            "lines-and-columns": "~2.0.3",
+            "minimatch": "3.0.5",
+            "npm-run-path": "^4.0.1",
+            "open": "^8.4.0",
+            "semver": "7.3.4",
+            "string-width": "^4.2.3",
+            "strong-log-transformer": "^2.1.0",
+            "tar-stream": "~2.2.0",
+            "tmp": "~0.2.1",
+            "tsconfig-paths": "^4.1.2",
+            "tslib": "^2.3.0",
+            "v8-compile-cache": "2.3.0",
+            "yargs": "^17.6.2",
+            "yargs-parser": "21.1.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "typescript": {
           "version": "4.9.5",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
           "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "8.0.1",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+              "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+              "dev": true,
+              "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
         }
       }
@@ -12239,22 +13228,21 @@
       }
     },
     "nx": {
-      "version": "15.9.3",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.3.tgz",
-      "integrity": "sha512-GLwbykfTABc7/UZjQEEnV1bQbTVC53W+Zj4xWY640/45I4iZf/TUqKMBCgtLZ9v89gEsKOM4zsx55CqHT3bekA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-16.2.1.tgz",
+      "integrity": "sha512-O+yGcYIQtYKYagbIuOQFk1P8ki5PHn0BZjdZpsa4K8UZ4pCaRWzlwWwwUL91FUJe6tdhic5710DwAAakbGKP7Q==",
       "dev": true,
       "requires": {
-        "@nrwl/cli": "15.9.3",
-        "@nrwl/nx-darwin-arm64": "15.9.3",
-        "@nrwl/nx-darwin-x64": "15.9.3",
-        "@nrwl/nx-linux-arm-gnueabihf": "15.9.3",
-        "@nrwl/nx-linux-arm64-gnu": "15.9.3",
-        "@nrwl/nx-linux-arm64-musl": "15.9.3",
-        "@nrwl/nx-linux-x64-gnu": "15.9.3",
-        "@nrwl/nx-linux-x64-musl": "15.9.3",
-        "@nrwl/nx-win32-arm64-msvc": "15.9.3",
-        "@nrwl/nx-win32-x64-msvc": "15.9.3",
-        "@nrwl/tao": "15.9.3",
+        "@nrwl/tao": "16.2.1",
+        "@nx/nx-darwin-arm64": "16.2.1",
+        "@nx/nx-darwin-x64": "16.2.1",
+        "@nx/nx-linux-arm-gnueabihf": "16.2.1",
+        "@nx/nx-linux-arm64-gnu": "16.2.1",
+        "@nx/nx-linux-arm64-musl": "16.2.1",
+        "@nx/nx-linux-x64-gnu": "16.2.1",
+        "@nx/nx-linux-x64-musl": "16.2.1",
+        "@nx/nx-win32-arm64-msvc": "16.2.1",
+        "@nx/nx-win32-x64-msvc": "16.2.1",
         "@parcel/watcher": "2.0.4",
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "^3.0.0-rc.18",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "lerna": "^6.0.1"
+    "lerna": "^6.0.1",
+    "nx": "^16.2.1"
   }
 }


### PR DESCRIPTION
Lerna allows us to set up a nx config for tasks. This can be used to add dependencies between tasks and make tasks cacheable.