### PR TITLE
fix incorrect unit

### DIFF
--- a/packages/expansion-hub/src/ExpansionHub.ts
+++ b/packages/expansion-hub/src/ExpansionHub.ts
@@ -58,7 +58,7 @@ export interface ExpansionHub extends RevHub {
     /**
      * Read the total current through the digital IO bus in mA
      */
-    getDigitalBusVoltage(): Promise<number>;
+    getDigitalBusCurrent(): Promise<number>;
 
     /**
      * Read the total current through the I2C busses in mA

--- a/packages/expansion-hub/src/internal/ExpansionHub.ts
+++ b/packages/expansion-hub/src/internal/ExpansionHub.ts
@@ -118,7 +118,7 @@ export class ExpansionHubInternal implements ExpansionHub {
         });
     }
 
-    async getDigitalBusVoltage(): Promise<number> {
+    async getDigitalBusCurrent(): Promise<number> {
         return this.convertErrorPromise(() => {
             return this.nativeRevHub.getADC(4, 0);
         });


### PR DESCRIPTION
The method for getting digital bus current incorrectly claimed to measure voltage.