### PR TITLE
use method to specify hub for query interface

### DIFF
--- a/packages/sample/src/main.ts
+++ b/packages/sample/src/main.ts
@@ -153,11 +153,10 @@ program
     .command("query <name>")
     .description("Query interface information")
     .action(async (name) => {
-        let hubs = await openConnectedExpansionHubs();
-        let hub = hubs[0];
+        let [hub, close] = await getExpansionHubOrThrow();
         await queryInterface(hub, name);
 
-        hub.close();
+        close();
     });
 
 program


### PR DESCRIPTION
The branch adding this method was created before specify-hub was merged, and it wasn't updated after merging.