### PR TITLE
Fix makefile generator build

### DIFF
--- a/packages/rhsplib/tsconfig.json
+++ b/packages/rhsplib/tsconfig.json
@@ -3,5 +3,11 @@
     "compilerOptions": {
         "outDir": "./dist",
         "rootDir": "./lib"
-    }
+    },
+    "include": [
+        "./lib/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
 }


### PR DESCRIPTION
When using the Makefile generator, CMake creates a file called 'compiler_commands.ts', which tracks the timestamp of each compiler command, allowing IDEs to track performance. Unfortunately, the typescript compiler assumes that all files ending with ts are typescript files. This PR specifies where typescript files will be.