### PR TITLE
Fix prepublishOnly scripts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,8 @@
         "typescript": "^5.0.2"
     },
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "prepublishOnly": "tsc"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/distance-sensor/package.json
+++ b/packages/distance-sensor/package.json
@@ -12,7 +12,8 @@
         "typescript": "^5.0.2"
     },
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "prepublishOnly": "tsc"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/expansion-hub/package.json
+++ b/packages/expansion-hub/package.json
@@ -14,7 +14,8 @@
         "typescript": "^5.0.2"
     },
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "prepublishOnly": "tsc"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/rhsplib/package.json
+++ b/packages/rhsplib/package.json
@@ -19,7 +19,6 @@
     },
     "devDependencies": {
         "@types/node": "^16.18.18",
-        "prebuildify": "^5.0.1",
         "typescript": "^5.0.2"
     },
     "scripts": {
@@ -27,7 +26,7 @@
         "install": "pkg-prebuilds-verify binding-options.cjs || cmake-js compile",
         "makePrebuildsOnLinux": "node scripts/linux-cross-build.mjs",
         "makePrebuildsOnDarwin": "node scripts/macos-cross-build.mjs",
-        "prepublishOnly": "prebuildify --napi && tsc",
+        "prepublishOnly": "tsc",
         "cross-build": "node-gyp-build \"node scripts/cross-build-RHSPlib.mjs\""
     },
     "publishConfig": {

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -14,7 +14,8 @@
         "typescript": "^5.0.2"
     },
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "prepublishOnly": "tsc"
     },
     "files": [
         "dist"


### PR DESCRIPTION
The rhsplib one still ran prebuildify, and the other packages didn't have a `prepublishOnly` script at all, which meant that the user was required to remember to run `npx lerna run build`.