### PR TITLE
Update publishing instructions for lerna

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,30 @@ We have several packages currently:
 
 ## Building and other tasks
 
-To build the app, run `lerna run build`.
+To build the app, run `npx lerna run build`.
 If you have other tasks you wish to create, define
 them in the module's package.json like normal, and run
-`lerna run mytask`. This will run 'mytask' in every
+`npx lerna run mytask`. This will run 'mytask' in every
 module that has a task with that name.
 
 Tasks in the top-level package.json can be run with
 `npm run` like normal.
 
-## Making a release (update when we learn more about lerna)
+## Making a release
 
-1. Check out the `main` branch
-2. Update `version` field in `package.json`
-3. Run `npm install`
-4. Commit package.json and package-lock.json to git
-5. Run `git tag v<version>`
-6. Run `git push`
-7. Run `git push --tags`
-8. Run `npm publish --access public`
-9. Create a new release on GitHub with an explanation of the changes
+1. Check out the `main` branch.
+2. Run `npm install` from the repository's root directory.
+3. If you've made any changes to the structure of the project, run `npm pack` in each package directory, and validate
+   that the packaged `.tgz` files contain everything that will be needed to use the library, but nothing more.
+   1. `README.md` files will always be included.
+   2. Make any necessary changes to the `files` property of the incorrect package's `package.json` file.
+4. Run `lerna publish`. This command will do the following:
+   1. Bump the versions of any packages that have changed since the last git tag, asking which version number should
+      get bumped for each one
+   2. Commit the version bumps and any `package-json.lock` changes
+   3. Create a git tag for each package that is being published, and push it to GitHub
+5. If `lerna publish failed`, see https://lerna.js.org/docs/faq#how-do-i-retry-publishing-if-publish-fails. Make sure
+   to remove any `gitHead` fields in `package.json` files.
+6. Go to https://github.com/REVrobotics/node-rhsplib/tags, select each new tag, and create a new release for each one.
+   1. Name the release `<package name> version <version>`
+   2. Write up a description of the changes to that specific package.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,5 @@
     },
     "files": [
         "dist"
-    ],
-    "gitHead": "a52ee196568bb3e01a576dada715789841e9c24c"
+    ]
 }

--- a/packages/distance-sensor/package.json
+++ b/packages/distance-sensor/package.json
@@ -21,6 +21,5 @@
     },
     "files": [
         "dist"
-    ],
-    "gitHead": "a52ee196568bb3e01a576dada715789841e9c24c"
+    ]
 }


### PR DESCRIPTION
This PR also removes leftover `gitHead` fields from `package.json` files. As it turns out, those are [meant to be temporary](https://github.com/lerna/lerna/issues/1880#issuecomment-456160357), and they were only added because the publish operation didn't finish successfully.