### PR TITLE
fix error when com greater than nine

### DIFF
--- a/packages/rhsplib/RHSPlib/arch/includes/RHSPlib_serial.h
+++ b/packages/rhsplib/RHSPlib/arch/includes/RHSPlib_serial.h
@@ -113,6 +113,12 @@ int RHSPlib_serial_write(RHSPlib_Serial_T *serial, const uint8_t *buffer, size_t
  * */
 void RHSPlib_serial_close(RHSPlib_Serial_T *serial);
 
+/**
+ * @brief Get the last error code from the OS.
+ * This is errno on unix, and GetLastError on windows.
+ * */
+int RHSPlib_getLastOsError(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/packages/rhsplib/RHSPlib/arch/linux/RHSPlib_serial.c
+++ b/packages/rhsplib/RHSPlib/arch/linux/RHSPlib_serial.c
@@ -10,6 +10,7 @@
 #include <termios.h>
 #include <time.h>
 #include <unistd.h>
+#include <errno.h>
 
 //#include "RHSPlib_compiler.h"
 #include "RHSPlib_serial.h"
@@ -330,4 +331,6 @@ static int baudrateToBits(uint32_t baudrate) {
     }
 }
 
-
+int RHSPlib_getLastOsError(void) {
+    return (int) GetLastError();
+}

--- a/packages/rhsplib/RHSPlib/arch/mac/RHSPlib_serial.c
+++ b/packages/rhsplib/RHSPlib/arch/mac/RHSPlib_serial.c
@@ -10,6 +10,7 @@
 #include <termios.h>
 #include <time.h>
 #include <unistd.h>
+#include <errno.h>
 
 //#include "RHSPlib_compiler.h"
 #include "RHSPlib_serial.h"
@@ -232,3 +233,6 @@ void RHSPlib_serial_close(RHSPlib_Serial_T *serial)
     serial->fd = -1;
 }
 
+int RHSPlib_getLastOsError(void) {
+    return errno;
+}

--- a/packages/rhsplib/RHSPlib/arch/win/RHSPlib_serial.c
+++ b/packages/rhsplib/RHSPlib/arch/win/RHSPlib_serial.c
@@ -240,3 +240,7 @@ void RHSPlib_serial_close(RHSPlib_Serial_T* serial)
         }
     }
 }
+
+int RHSPlib_getLastOsError(void) {
+    return (int) GetLastError();
+}

--- a/packages/rhsplib/RHSPlib/arch/win/RHSPlib_serial.c
+++ b/packages/rhsplib/RHSPlib/arch/win/RHSPlib_serial.c
@@ -107,9 +107,12 @@ int RHSPlib_serial_open(RHSPlib_Serial_T* serial, const char* serialPortName,
     {
         return RHSPLIB_SERIAL_ERROR;
     }
+
+    char modifiedSerialPortName[20];
+    snprintf(modifiedSerialPortName, 20, "\\\\.\\%s", serialPortName);
     
     /* Try to open specified COM-port */
-    serial->handle = CreateFile(serialPortName,
+    serial->handle = CreateFile(modifiedSerialPortName,
                                 GENERIC_READ | GENERIC_WRITE,
                                 0,      //  must be opened with exclusive-access
                                 NULL,   //  default security attributes

--- a/packages/rhsplib/src/serialWrapper.cc
+++ b/packages/rhsplib/src/serialWrapper.cc
@@ -49,6 +49,10 @@ Napi::Value Serial::open(const Napi::CallbackInfo &info) {
         const char *serialPortName = serialPortNameStr.c_str();
         _code = RHSPlib_serial_open(&this->serialPort, serialPortName, baudrate,
                                     databits, parity, stopbits, flowControl);
+
+        if(_code != 0) {
+            _osErrorCode = RHSPlib_getLastOsError();
+        }
     });
 
     QUEUE_WORKER(worker);


### PR DESCRIPTION
On Windows, there's a special syntax needed for when the COM port is greater than 9