### PR TITLE
Port last error code and device path fixes from librhsp

### DIFF
--- a/packages/rhsplib/librhsp/include/rhsp/serial.h
+++ b/packages/rhsplib/librhsp/include/rhsp/serial.h
@@ -113,6 +113,12 @@ int rhsp_serialWrite(RhspSerial* serial, const uint8_t* buffer, size_t bytesToWr
  * */
 void rhsp_serialClose(RhspSerial* serial);
 
+/**
+ * @brief Get the last error code from the OS.
+ * This is errno on unix, and GetLastError on windows.
+ * */
+int rhsp_getLastOsError();
+
 #ifdef __cplusplus
 }
 #endif

--- a/packages/rhsplib/librhsp/src/arch/linux/serial.c
+++ b/packages/rhsplib/librhsp/src/arch/linux/serial.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <termios.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "rhsp/serial.h"
 
@@ -359,4 +360,6 @@ static int baudrateToBits(uint32_t baudrate)
     }
 }
 
-
+int rhsp_getLastOsError() {
+    return errno;
+}

--- a/packages/rhsplib/librhsp/src/arch/mac/serial.c
+++ b/packages/rhsplib/librhsp/src/arch/mac/serial.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <termios.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "rhsp/serial.h"
 
@@ -226,5 +227,9 @@ void rhsp_serialClose(RhspSerial* serial)
         return;
     }
     serial->fd = -1;
+}
+
+int rhsp_getLastOsError() {
+    return errno;
 }
 

--- a/packages/rhsplib/librhsp/src/arch/win/serial.c
+++ b/packages/rhsplib/librhsp/src/arch/win/serial.c
@@ -109,9 +109,18 @@ int rhsp_serialOpen(RhspSerial* serial,
     {
         return RHSP_SERIAL_ERROR;
     }
+
+    char modifiedSerialPortName[20];
+
+    // if the user has already prefixed the workaround, don't add it again
+    if(serialPort[0] == '\\') {
+        strncpy(modifiedSerialPortName, serialPort, 20);
+    } else {
+        snprintf(modifiedSerialPortName, 20, "\\\\.\\%s", serialPort);
+    }
     
     /* Try to open specified COM-port */
-    serial->handle = CreateFile(serialPort,
+    serial->handle = CreateFile(modifiedSerialPortName,
                                 GENERIC_READ | GENERIC_WRITE,
                                 0,      //  must be opened with exclusive-access
                                 NULL,   //  default security attributes
@@ -241,4 +250,8 @@ void rhsp_serialClose(RhspSerial* serial)
             serial->handle = INVALID_HANDLE_VALUE;
         }
     }
+}
+
+int rhsp_getLastOsError(void) {
+    return (int) GetLastError();
 }


### PR DESCRIPTION
Replaces #131 

Windows requires devices to add a special prefix to access them as files. It aliases COM0-COM9, but other ports are not aliased. We modify the path here to allow the user to pass "COM10" as-is.